### PR TITLE
Bump io.undertow:undertow-core from 2.3.15.Final to 2.3.17.Final

### DIFF
--- a/environments/se/pom.xml
+++ b/environments/se/pom.xml
@@ -24,7 +24,7 @@
     </description>
 
    <properties>
-      <undertow.version>2.3.15.Final</undertow.version>
+      <undertow.version>2.3.17.Final</undertow.version>
    </properties>
 
    <dependencyManagement>


### PR DESCRIPTION
### Description

In this pull request, the version of Undertow in the Project Object Model (POM) file named `pom.xml` located in the `environments/se` directory has been updated.

- Update the Undertow version in the project's POM file from `2.3.15.Final` to `2.3.17.Final`.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Bump `io.undertow:undertow-core` version from `2.3.15.Final` to `2.3.17.Final` in `pom.xml`.

### Why are these changes being made?

This version update is made to incorporate the latest bug fixes and improvements from the Undertow library, enhancing stability and potentially addressing vulnerabilities present in the previous version. Maintaining dependencies at their latest versions is essential for optimal application performance and security.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->